### PR TITLE
update to 0.18.2

### DIFF
--- a/keptn-end-to-end-delivery/assets/scripts/add_approval_step.sh
+++ b/keptn-end-to-end-delivery/assets/scripts/add_approval_step.sh
@@ -11,8 +11,8 @@ spec:
       sequences:
         - name: "delivery"
           tasks:
-            - name: "je-deployment"
-            - name: "je-test"
+            - name: "deployment"
+            - name: "test"
 
     - name: "production"
       sequences:
@@ -24,7 +24,7 @@ spec:
               properties:
                 pass: "manual"
                 warning: "manual"
-            - name: "je-deployment"
+            - name: "deployment"
 EOF
 git remote set-url origin https://$GIT_USER:$GITHUB_TOKEN@github.com/$GIT_USER/$GIT_NEW_REPO_NAME.git
 git config --global user.email "keptn@keptn.sh"

--- a/keptn-end-to-end-delivery/assets/scripts/quality_gated_release.sh
+++ b/keptn-end-to-end-delivery/assets/scripts/quality_gated_release.sh
@@ -20,8 +20,8 @@ spec:
       sequences:
         - name: "delivery"
           tasks:
-            - name: "je-deployment"
-            - name: "je-test"
+            - name: "deployment"
+            - name: "test"
             - name: "evaluation"
               properties:
                 timeframe: "2m"
@@ -36,7 +36,7 @@ spec:
               properties:
                 pass: "automatic"
                 warning: "automatic"
-            - name: "je-deployment"
+            - name: "deployment"
 EOF
 git remote set-url origin https://$GIT_USER:$GITHUB_TOKEN@github.com/$GIT_USER/$GIT_NEW_REPO_NAME.git
 git config --global user.email "keptn@keptn.sh"

--- a/keptn-end-to-end-delivery/assets/scripts/release_validation.sh
+++ b/keptn-end-to-end-delivery/assets/scripts/release_validation.sh
@@ -30,8 +30,8 @@ spec:
       sequences:
         - name: "delivery"
           tasks:
-            - name: "je-deployment"
-            - name: "je-test"
+            - name: "deployment"
+            - name: "test"
             - name: "evaluation"
               properties:
                 timeframe: "2m"
@@ -46,8 +46,8 @@ spec:
               properties:
                 pass: "automatic"
                 warning: "automatic"
-            - name: "je-deployment"
-            - name: "je-test"
+            - name: "deployment"
+            - name: "test"
             - name: "evaluation"
               properties:
                 timeframe: "2m"

--- a/keptn-end-to-end-delivery/assets/scripts/self_healing.sh
+++ b/keptn-end-to-end-delivery/assets/scripts/self_healing.sh
@@ -13,8 +13,8 @@ spec:
       sequences:
         - name: "delivery"
           tasks:
-            - name: "je-deployment"
-            - name: "je-test"
+            - name: "deployment"
+            - name: "test"
             - name: "evaluation"
               properties:
                 timeframe: "2m"
@@ -29,8 +29,8 @@ spec:
               properties:
                 pass: "automatic"
                 warning: "automatic"
-            - name: "je-deployment"
-            - name: "je-test"
+            - name: "deployment"
+            - name: "test"
             - name: "evaluation"
               properties:
                 timeframe: "2m"
@@ -44,7 +44,7 @@ spec:
           tasks:
             - name: "get-action"
             - name: "action"
-            - name: "je-test"
+            - name: "test"
             - name: "evaluation"
               properties:
                 timeframe: "2m"
@@ -94,7 +94,7 @@ apiVersion: v2
 actions:
   - name: "Deploy using helm"
     events:
-      - name: "sh.keptn.event.je-deployment.triggered"
+      - name: "sh.keptn.event.deployment.triggered"
     tasks:
       - name: "Run helm"
         files:
@@ -110,7 +110,7 @@ actions:
 
   - name: "Run tests using locust"
     events:
-      - name: "sh.keptn.event.je-test.triggered"
+      - name: "sh.keptn.event.test.triggered"
     tasks:
       - name: "Run locust"
         files:

--- a/keptn-end-to-end-delivery/assets/scripts/setup_keptn.sh
+++ b/keptn-end-to-end-delivery/assets/scripts/setup_keptn.sh
@@ -15,8 +15,8 @@ spec:
       sequences:
         - name: "delivery"
           tasks:
-            - name: "je-deployment"
-            - name: "je-test"
+            - name: "deployment"
+            - name: "test"
 
     - name: "production"
       sequences:
@@ -24,7 +24,7 @@ spec:
           triggeredOn:
             - event: "qa.delivery.finished"
           tasks:
-            - name: "je-deployment"
+            - name: "deployment"
 EOF
 
 echo ""

--- a/keptn-end-to-end-delivery/index.json
+++ b/keptn-end-to-end-delivery/index.json
@@ -1,9 +1,9 @@
 {
 
 	"title": "Keptn End to End Delivery",
-	"description": "Keptn uses a declarative approach to build scalable automation for delivery and operations which can be scaled to a large number of services.",
+	"description": "Keptn uses a declarative approach to build automation for delivery and operations which can be scaled to a large number of services.",
 	"difficulty": "Medium",
-	"time": "10",
+	"time": "50",
 	"details": {
 		"steps": [{
 				"title": "Keptn Bridge",

--- a/keptn-end-to-end-delivery/intro_foreground.sh
+++ b/keptn-end-to-end-delivery/intro_foreground.sh
@@ -3,78 +3,145 @@
 # -----------------------------------------#
 K3D_VERSION=v5.3.0
 KUBECTL_VERSION=v1.22.6
-GH_CLI_VERSION=2.14.1
-KEPTN_VERSION=0.17.0
-JOB_EXECUTOR_SERVICE_VERSION=0.2.3
-KEPTN_PROMETHEUS_SERVICE_VERSION=0.8.3
-PROMETHEUS_VERSION=15.10.1
+GH_CLI_VERSION=2.14.7
+KEPTN_VERSION=0.18.2
+JOB_EXECUTOR_SERVICE_VERSION=0.2.5
+JOB_EXECUTOR_NAMESPACE=keptn-jes
+KEPTN_PROMETHEUS_SERVICE_VERSION=0.9.1
+PROMETHEUS_VERSION=15.12.0
+
+# ----------------------------------------#
+#      Step 1/13: Installing Kubectl      #
+# ----------------------------------------#
+curl -LO https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl
+sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
 # -----------------------------------------#
-#    Step 1/11: Installing GitHub CLI      #
+#    Step 2/13: Initialising Kubernetes    #
+# -----------------------------------------#
+curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=$K3D_VERSION bash
+k3d cluster create mykeptn -p "8080:80@loadbalancer" --k3s-arg "--no-deploy=traefik@server:*"
+
+# ----------------------------------------#
+#      Step 3/13: Installing Helm         #
+# ----------------------------------------#
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && chmod 700 get_helm.sh
+./get_helm.sh
+
+# -------------------------------------------#
+# Step 4/13: Installing Keptn Control Plane  #
+# -------------------------------------------#
+helm install keptn https://github.com/keptn/keptn/releases/download/$KEPTN_VERSION/keptn-$KEPTN_VERSION.tgz \
+-n keptn --create-namespace \
+--set=apiGatewayNginx.type=LoadBalancer \
+--set mongo.resources.requests.cpu=0 \
+--set mongo.resources.requests.memory=0 \
+--set nats.nats.resources.requests.cpu=0 \
+--set nats.nats.resources.requests.memory=0 \
+--set nats.nats.jetstream.memStorage.size=0M \
+--set apiGatewayNginx.resources.requests.cpu=0 \
+--set apiGatewayNginx.resources.requests.memory=0 \
+--set remediationService.resources.requests.cpu=0 \
+--set remediationService.resources.requests.memory=0 \
+--set apiService.resources.requests.cpu=0 \
+--set apiService.resources.requests.memory=0 \
+--set bridge.resources.requests.cpu=0 \
+--set bridge.resources.requests.memory=0 \
+--set distributor.resources.requests.cpu=0 \
+--set distributor.resources.requests.memory=0 \
+--set shipyardController.resources.requests.cpu=0 \
+--set shipyardController.resources.requests.memory=0 \
+--set secretService.resources.requests.cpu=0 \
+--set secretService.resources.requests.memory=0 \
+--set configurationService.resources.requests.cpu=0 \
+--set configurationService.resources.requests.memory=0 \
+--set resourceService.resources.requests.cpu=0 \
+--set resourceService.resources.requests.memory=0 \
+--set mongodbDatastore.resources.requests.cpu=0 \
+--set mongodbDatastore.resources.requests.memory=0 \
+--set lighthouseService.resources.requests.cpu=0 \
+--set lighthouseService.resources.requests.memory=0 \
+--set statisticsService.enabled=false \
+--set approvalService.resources.requests.cpu=0 \
+--set approvalService.resources.requests.memory=0 \
+--set webhookService.resources.requests.cpu=0 \
+--set webhookService.resources.requests.memory=0
+
+# --------------------------------------------#
+# Step 5/13: Installing Prometheus Service   #
+# --------------------------------------------#
+helm install -n keptn prometheus-service https://github.com/keptn-contrib/prometheus-service/releases/download/$KEPTN_PROMETHEUS_SERVICE_VERSION/prometheus-service-$KEPTN_PROMETHEUS_SERVICE_VERSION.tgz --set resources.requests.cpu=0m
+
+# -----------------------------------------#
+#    Step 6/13: Installing Prometheus      #
+# -----------------------------------------#
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm install prometheus prometheus-community/prometheus \
+--namespace monitoring --create-namespace \
+--version ${PROMETHEUS_VERSION}
+
+# --------------------------------------------#
+# Step 7/13: Installing Prometheus Service   #
+# --------------------------------------------#
+helm install -n keptn prometheus-service https://github.com/keptn-contrib/prometheus-service/releases/download/$KEPTN_PROMETHEUS_SERVICE_VERSION/prometheus-service-$KEPTN_PROMETHEUS_SERVICE_VERSION.tgz --set resources.requests.cpu=0m
+kubectl -n monitoring apply -f https://raw.githubusercontent.com/keptn-contrib/prometheus-service/$KEPTN_PROMETHEUS_SERVICE_VERSION/deploy/role.yaml
+
+# --------------------------------------------#
+# Step 8/13: Installing Job Executor Service  #
+# --------------------------------------------#
+KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 -d)
+helm install --namespace $JOB_EXECUTOR_NAMESPACE \
+--create-namespace \
+--set=remoteControlPlane.api.hostname=api-gateway-nginx.keptn \
+--set=remoteControlPlane.api.token=$KEPTN_API_TOKEN --set=remoteControlPlane.topicSubscription="sh.keptn.event.deployment.triggered\,sh.keptn.event.test.triggered\,sh.keptn.event.action.triggered" \
+job-executor-service https://github.com/keptn-contrib/job-executor-service/releases/download/$JOB_EXECUTOR_SERVICE_VERSION/job-executor-service-$JOB_EXECUTOR_SERVICE_VERSION.tgz
+
+# -----------------------------------------#
+#      Step 9/13: Installing Keptn CLI     #
+# -----------------------------------------#
+curl -sL https://get.keptn.sh | KEPTN_VERSION=$KEPTN_VERSION bash
+
+# ---------------------------------------------#
+# Step 10/13: Apply Cluster Admin Role for JES #
+# ---------------------------------------------#
+kubectl apply -f ~/keptn-job-executor-delivery-poc/job-executor/workloadClusterRoles.yaml
+
+# -----------------------------------------#
+#    Step 11/13: Installing GitHub CLI      #
 # -----------------------------------------#
 wget -q https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.deb
 chmod +x gh_${GH_CLI_VERSION}_linux_amd64.deb
 dpkg -i gh_${GH_CLI_VERSION}_linux_amd64.deb
 
 # -----------------------------------------#
-#    Step 2/11: Retrieving demo files      #
+#    Step 12/13: Retrieving demo files     #
 # -----------------------------------------#
 git clone https://github.com/christian-kreuzberger-dtx/keptn-job-executor-delivery-poc.git
 
 # -----------------------------------------#
-#      Step 3/11: Installing Keptn CLI     #
+#    Step 13/13: Wait for all pods         #
 # -----------------------------------------#
-curl -sL https://get.keptn.sh | KEPTN_VERSION=$KEPTN_VERSION bash
+kubectl -n monitoring wait --for condition=Available=True --timeout=5m deployment/prometheus-kube-state-metrics
+kubectl -n monitoring wait --for condition=Available=True --timeout=5m deployment/prometheus-pushgateway
+kubectl -n monitoring wait --for condition=Available=True --timeout=5m deployment/prometheus-alertmanager
+kubectl -n monitoring wait --for condition=Available=True --timeout=5m deployment/prometheus-server
+kubectl -n keptn-jes wait --for condition=Available=True --timeout=5m deployment/job-executor-service
+kubectl -n keptn wait --for condition=Available=True --timeout=5m deployment/api-gateway-nginx
+kubectl -n keptn wait --for condition=Available=True --timeout=5m deployment/resource-service
+kubectl -n keptn wait --for condition=Available=True --timeout=5m deployment/secret-service
+kubectl -n keptn wait --for condition=Available=True --timeout=5m deployment/api-service
+kubectl -n keptn wait --for condition=Available=True --timeout=5m deployment/bridge
+kubectl -n keptn wait --for condition=Available=True --timeout=5m deployment/mongodb-datastore
+kubectl -n keptn wait --for condition=Available=True --timeout=5m deployment/keptn-mongo
+kubectl -n keptn wait --for condition=Available=True --timeout=5m deployment/shipyard-controller
+kubectl -n keptn wait --for condition=Available=True --timeout=5m deployment/remediation-service
+kubectl -n keptn wait --for condition=Available=True --timeout=5m deployment/approval-service
+kubectl -n keptn wait --for condition=Available=True --timeout=5m deployment/webhook-service
+kubectl -n keptn wait --for condition=Available=True --timeout=5m deployment/lighthouse-service
+kubectl -n keptn wait --for condition=Available=True --timeout=5m deployment/prometheus-service
 
-# ----------------------------------------#
-#      Step 4/11: Installing Helm         #
-# ----------------------------------------#
-curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && chmod 700 get_helm.sh
-./get_helm.sh
-
-# ----------------------------------------#
-#      Step 5/11: Installing Kubectl      #
-# ----------------------------------------#
-curl -LO https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl
-sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-
-# -----------------------------------------#
-#    Step 6/11: Initialising Kubernetes    #
-# -----------------------------------------#
-curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=$K3D_VERSION bash
-k3d cluster create mykeptn -p "8080:80@loadbalancer" --k3s-arg "--no-deploy=traefik@server:*"
-
-
-# -----------------------------------------#
-#    Step 7/11: Installing Prometheus      #
-# -----------------------------------------#
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm install prometheus prometheus-community/prometheus --namespace monitoring --create-namespace --version ${PROMETHEUS_VERSION} --wait
-
-# -------------------------------------------#
-# Step 8/11: Installing Keptn Control Plane  #
-# -------------------------------------------#
-helm install keptn https://github.com/keptn/keptn/releases/download/$KEPTN_VERSION/keptn-$KEPTN_VERSION.tgz -n keptn --timeout=5m --wait --create-namespace --set=apiGatewayNginx.type=LoadBalancer
-
-# --------------------------------------------#
-# Step 9/11: Installing Job Executor Service  #
-# --------------------------------------------#
-KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 -d)
-helm install --namespace keptn-jes --create-namespace --wait --timeout=4m --set=remoteControlPlane.api.hostname=api-gateway-nginx.keptn --set=remoteControlPlane.api.token=$KEPTN_API_TOKEN --set=remoteControlPlane.topicSubscription="sh.keptn.event.je-deployment.triggered\,sh.keptn.event.je-test.triggered\,sh.keptn.event.action.triggered" \
-job-executor-service https://github.com/keptn-contrib/job-executor-service/releases/download/$JOB_EXECUTOR_SERVICE_VERSION/job-executor-service-$JOB_EXECUTOR_SERVICE_VERSION.tgz
-
-# --------------------------------------------#
-# Step 10/11: Installing Prometheus Service   #
-# --------------------------------------------#
-helm install -n keptn prometheus-service https://github.com/keptn-contrib/prometheus-service/releases/download/$KEPTN_PROMETHEUS_SERVICE_VERSION/prometheus-service-$KEPTN_PROMETHEUS_SERVICE_VERSION.tgz --set resources.requests.cpu=25m
-kubectl -n monitoring apply -f https://raw.githubusercontent.com/keptn-contrib/prometheus-service/$KEPTN_PROMETHEUS_SERVICE_VERSION/deploy/role.yaml
 
 # ---------------------------------------------#
-# Step 11/11: Apply Cluster Admin Role for JES #
-# ---------------------------------------------#
-kubectl apply -f ~/keptn-job-executor-delivery-poc/job-executor/workloadClusterRoles.yaml
-
-# ---------------------------------------------#
-#       🎉 Installation Complete 🎉          #
+#       🎉 Installation Complete 🎉             #
 #           Please proceed now...              #
 # ---------------------------------------------#

--- a/keptn-end-to-end-delivery/step2.md
+++ b/keptn-end-to-end-delivery/step2.md
@@ -4,8 +4,6 @@ Keptn needs a brand new, uninitialised repo to store and manage configuration. W
 
 Run this script to set your details. If you make a mistake, just click this again to reset things:
 
-*💡 Hint: `Ctrl + Shift + v` works well in the terminal window to paste*
-
 ```
 . ~/set_git_details.sh
 ```{{exec}}
@@ -27,7 +25,7 @@ Run the following script which will:
 
 Everything is setup correctly and the first artifact delivery sequence has been triggered. Watch progress in [the bridge]({{TRAFFIC_HOST1_8080}}/bridge/project/fulltour/sequence).
 
-Locust runs for 2 minutes (configurable) each time it responds to `je-test.triggered`. Load is generated once in the `qa` stage so expect the end-to-end delivery with Locust load tests to take about 3 minutes.
+Locust runs for 2 minutes (configurable) each time it responds to `test.triggered`. Load is generated once in the `qa` stage so expect the end-to-end delivery with Locust load tests to take about 3 minutes.
 
 ![deployed](./assets/trigger-delivery-2.jpg)
 


### PR DESCRIPTION
# Critical Changes
- Fixes tutorial due to change in referenced PoC repo which changed tasks `je-deployment` to `deployment` and `je-test` to `test`. Breaking this demo.

# Major Changes
- Updates to Keptn 0.18.2
- Re-orders install to feel faster

# Minor Changes
- Updates to Prometheus 15.12.0
- Updates to Prometheus service 0.9.1

Signed-off-by: agardnerit <adam@agardner.net>