### PR TITLE
fix: Killercoda new issue link redirect correction

### DIFF
--- a/keptn-end-to-end-delivery/finish.md
+++ b/keptn-end-to-end-delivery/finish.md
@@ -19,4 +19,4 @@ It is almost guaranteed that Keptn works with your tool. Want to know if someone
 
 Want to suggest (or submit) a new tooling integration that Keptn could / should work with? [Ask for it or submit it here](https://github.com/keptn/integrations/issues).
 
-Found a bug or issue? [Create an issue on GitHub](https://github.com/)
+Found a bug or issue? [Create an issue on GitHub]([https://github.com/](https://github.com/afzal442/keptn-pg-killerway/issues/new))

--- a/keptn-end-to-end-delivery/finish.md
+++ b/keptn-end-to-end-delivery/finish.md
@@ -19,4 +19,4 @@ It is almost guaranteed that Keptn works with your tool. Want to know if someone
 
 Want to suggest (or submit) a new tooling integration that Keptn could / should work with? [Ask for it or submit it here](https://github.com/keptn/integrations/issues).
 
-Found a bug or issue? [Create an issue on GitHub]([https://github.com/](https://github.com/afzal442/keptn-pg-killerway/issues/new))
+Found a bug or issue? [Create an issue on GitHub][https://github.com/afzal442/keptn-pg-killerway/issues/new]

--- a/keptn-end-to-end-delivery/finish.md
+++ b/keptn-end-to-end-delivery/finish.md
@@ -19,4 +19,4 @@ It is almost guaranteed that Keptn works with your tool. Want to know if someone
 
 Want to suggest (or submit) a new tooling integration that Keptn could / should work with? [Ask for it or submit it here](https://github.com/keptn/integrations/issues).
 
-Found a bug or issue? [Create an issue on GitHub][https://github.com/afzal442/keptn-pg-killerway/issues/new]
+Found a bug or issue? [Create an issue on GitHub](https://github.com/afzal442/keptn-pg-killerway/issues/new)


### PR DESCRIPTION
The final page link to new issue creation in killercoda demo is updated from the GitHub homepage to [here](https://github.com/afzal442/keptn-pg-killerway/issues/new).

Issue Link - https://github.com/keptn/keptn/issues/9502