### PR TITLE
Replace k3d with Killercoda-Native

### DIFF
--- a/keptn-end-to-end-delivery/index.json
+++ b/keptn-end-to-end-delivery/index.json
@@ -143,6 +143,6 @@
 		"uilayout": "terminal"
 	},
 	"backend": {
-		"imageid": "ubuntu:2004"
+		"imageid": "kubernetes-kubeadm-2nodes"
 	}
 }

--- a/keptn-end-to-end-delivery/intro_foreground.sh
+++ b/keptn-end-to-end-delivery/intro_foreground.sh
@@ -2,7 +2,6 @@
 #        Setting Global variables          #
 # -----------------------------------------#
 DEBUG_VERSION=1
-K3D_VERSION=v5.3.0
 KUBECTL_VERSION=v1.22.6
 GH_CLI_VERSION=2.23.0
 KEPTN_VERSION=1.2.0
@@ -13,25 +12,19 @@ PROMETHEUS_VERSION=19.0.1
 POD_WAIT_TIMEOUT_MINS=10
 
 # ----------------------------------------#
-#      Step 1/10: Installing Kubectl      #
+#      Step 1/9: Installing Kubectl      #
 # ----------------------------------------#
 curl -LO https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl
 sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
-# -----------------------------------------#
-#    Step 2/10: Initialising Kubernetes    #
-# -----------------------------------------#
-curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=$K3D_VERSION bash
-k3d cluster create mykeptn -p "8080:80@loadbalancer" --k3s-arg "--no-deploy=traefik@server:*"
-
 # ----------------------------------------#
-#      Step 3/10: Installing Helm         #
+#      Step 2/9: Installing Helm         #
 # ----------------------------------------#
 curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && chmod 700 get_helm.sh
 ./get_helm.sh
 
 # -------------------------------------------#
-# Step 4/10: Installing Keptn Control Plane  #
+# Step 3/9: Installing Keptn Control Plane  #
 # -------------------------------------------#
 helm install keptn https://github.com/keptn/keptn/releases/download/$KEPTN_VERSION/keptn-$KEPTN_VERSION.tgz \
 -n keptn --create-namespace \
@@ -71,7 +64,7 @@ helm install keptn https://github.com/keptn/keptn/releases/download/$KEPTN_VERSI
 --set webhookService.resources.requests.memory=0
 
 # -----------------------------------------#
-#    Step 5/10: Installing Prometheus      #
+#    Step 4/9: Installing Prometheus      #
 # -----------------------------------------#
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm install prometheus prometheus-community/prometheus \
@@ -79,12 +72,12 @@ helm install prometheus prometheus-community/prometheus \
 --version ${PROMETHEUS_VERSION}
 
 # --------------------------------------------#
-# Step 6/10: Installing Prometheus Service   #
+# Step 5/9: Installing Prometheus Service   #
 # --------------------------------------------#
 helm install -n keptn prometheus-service https://github.com/keptn-contrib/prometheus-service/releases/download/$KEPTN_PROMETHEUS_SERVICE_VERSION/prometheus-service-$KEPTN_PROMETHEUS_SERVICE_VERSION.tgz --set resources.requests.cpu=0m
 
 # --------------------------------------------#
-# Step 7/10: Installing Job Executor Service  #
+# Step 6/9: Installing Job Executor Service  #
 # --------------------------------------------#
 KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 -d)
 helm install --namespace $JOB_EXECUTOR_NAMESPACE \
@@ -95,19 +88,19 @@ job-executor-service https://github.com/keptn-contrib/job-executor-service/relea
 kubectl apply -f https://raw.githubusercontent.com/christian-kreuzberger-dtx/keptn-job-executor-delivery-poc/main/job-executor/workloadClusterRoles.yaml
 
 # -----------------------------------------#
-#      Step 8/10: Installing Keptn CLI     #
+#      Step 7/9: Installing Keptn CLI     #
 # -----------------------------------------#
 curl -sL https://get.keptn.sh | KEPTN_VERSION=$KEPTN_VERSION bash
 
 # -----------------------------------------#
-#    Step 9/10: Installing GitHub CLI      #
+#    Step 8/9: Installing GitHub CLI      #
 # -----------------------------------------#
 wget -q https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.deb
 chmod +x gh_${GH_CLI_VERSION}_linux_amd64.deb
 dpkg -i gh_${GH_CLI_VERSION}_linux_amd64.deb
 
 # -----------------------------------------#
-#    Step 10/10: Wait for all pods         #
+#    Step 9/9: Wait for all pods         #
 # -----------------------------------------#
 kubectl -n monitoring wait --for condition=Available=True --timeout=${POD_WAIT_TIMEOUT_MINS}m deployment/prometheus-kube-state-metrics
 kubectl -n monitoring wait --for condition=Available=True --timeout=${POD_WAIT_TIMEOUT_MINS}m deployment/prometheus-prometheus-pushgateway


### PR DESCRIPTION
Fixes #82 

This PR consists of the following changes-
- Removed step 2 from `intro_foreground.sh`, i.e to initialize a k8s cluster on `k3d`.
- Update the `imageid` to `kubernetes-kubeadm-2nodes` in `index.json`